### PR TITLE
Fix installation prefix for linux build

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Assuming CMake and Visual Studio are installed on your machine,
 Assuming CMake in installed on your machine,
 
 * Step in ```cmake``` directory
-* Run the command ```cmake ../Sources/```
+* Run the command ```cmake ../Sources/ -DCMAKE_INSTALL_PREFIX="$(pwd)"```
 * Run the command ```make```
 * Run the command ```make install```
 * The SO should be created in the ```./Binaries/Linux``` directory.


### PR DESCRIPTION
I had a similar problem as #9. Turns out this line https://github.com/jsgonsette/Wizium/blob/master/Sources/CMakeLists.txt#L5 has no effect and make tries to install the .so to /usr/local/../Binaries/Linux.

This is fixed if the commands in the updated README are used.